### PR TITLE
Change zoom level to power of 2

### DIFF
--- a/src/main/java/kaptainwutax/minemap/ui/map/MapManager.java
+++ b/src/main/java/kaptainwutax/minemap/ui/map/MapManager.java
@@ -45,7 +45,7 @@ public class MapManager {
     public MapManager(MapPanel panel, int blocksPerFragment) {
         this.panel = panel;
         this.blocksPerFragment = blocksPerFragment;
-        this.pixelsPerFragment = (int) (300.0D * (this.blocksPerFragment / DEFAULT_REGION_SIZE));
+        this.pixelsPerFragment = (int) (256.0D * (this.blocksPerFragment / DEFAULT_REGION_SIZE));
 
         this.panel.addMouseMotionListener(Events.Mouse.onDragged(e -> {
             if (SwingUtilities.isLeftMouseButton(e)) {
@@ -102,18 +102,18 @@ public class MapManager {
                 double newPixelsPerFragment = this.pixelsPerFragment;
 
                 if (e.getUnitsToScroll() > 0) {
-                    newPixelsPerFragment /= e.getUnitsToScroll() / 2.0D;
+                    newPixelsPerFragment /= 2.0D;
                 } else {
-                    newPixelsPerFragment *= -e.getUnitsToScroll() / 2.0D;
+                    newPixelsPerFragment *= 2.0D;
                 }
 
-                if (newPixelsPerFragment > 2000.0D * (double) this.blocksPerFragment / DEFAULT_REGION_SIZE) {
-                    newPixelsPerFragment = 2000.0D * (this.blocksPerFragment / 512.0D);
+                if (newPixelsPerFragment > 2048.0D * (double) this.blocksPerFragment / DEFAULT_REGION_SIZE) {
+                    newPixelsPerFragment = 2048.0D * (this.blocksPerFragment / 512.0D);
                 }
 
                 if (Configs.USER_PROFILE.getUserSettings().restrictMaximumZoom
-                        && newPixelsPerFragment < 40.0D * (double) this.blocksPerFragment / DEFAULT_REGION_SIZE) {
-                    newPixelsPerFragment = 40.0D * (this.blocksPerFragment / 512.0D);
+                        && newPixelsPerFragment < 32.0D * (double) this.blocksPerFragment / DEFAULT_REGION_SIZE) {
+                    newPixelsPerFragment = 32.0D * (this.blocksPerFragment / 512.0D);
                 }
 
                 double scaleFactor = newPixelsPerFragment / this.pixelsPerFragment;


### PR DESCRIPTION
Default zoom is 2 blocks per pixel,  zoom in is a max of 4 pixels per block, zoom out is 1 chunk per pixel. 

This makes exporting images easier as each pixel could be exactly 1 block per pixel or 1 chunk per 1 pixel.

If zoom multiply/divide by 2 is too much, one could do sqrt(2) or cubic root of 2, but because of double precision, it might be a bit wonky.

Also getUnitsToScroll is based on the windows setting, if I set windows settings to 2, minemap doesn't zoom, if the setting is 1, it's inverted, and if it's 100, then I'm stuck at either the maxZoom or minZoom.